### PR TITLE
Add Notion button click detection and side panel integration

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -1,0 +1,28 @@
+chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
+  console.log('Background received message:', request.action);
+  
+  if (request.action === 'openSidePanel') {
+    const tabId = sender.tab.id;
+    console.log('Opening side panel for tab:', tabId);
+    
+    chrome.sidePanel.open({ tabId }).then(() => {
+      console.log('Side panel opened successfully');
+      chrome.storage.local.set({
+        'currentRowData': request.data,
+        'tabId': tabId
+      });
+    }).catch((error) => {
+      console.error('Failed to open side panel:', error);
+    });
+  }
+  
+  return true;
+});
+
+chrome.runtime.onStartup.addListener(() => {
+  console.log('ShellAgent background script started');
+});
+
+chrome.runtime.onInstalled.addListener(() => {
+  console.log('ShellAgent extension installed');
+});

--- a/src/content.js
+++ b/src/content.js
@@ -1,1 +1,64 @@
 console.log('ShellAgent content script loaded');
+
+function isNotionButton(element) {
+  const span = element.querySelector('span');
+  return element.getAttribute('role') === 'button' && 
+         element.style.cursor === 'pointer' &&
+         element.style.display === 'inline-flex' &&
+         span?.textContent?.trim() === 'button';
+}
+
+function extractRowData(buttonElement) {
+  const tableRow = buttonElement.closest('.notion-table-view-row');
+  if (!tableRow) return null;
+  
+  const cells = Array.from(tableRow.querySelectorAll('.notion-table-view-cell'));
+  const rowData = {};
+  
+  cells.forEach((cell, index) => {
+    const textContent = cell.textContent?.trim();
+    if (textContent && textContent !== 'button') {
+      switch(index) {
+        case 0:
+          rowData.name = textContent;
+          break;
+        case 1:
+          rowData.type = textContent;
+          break;
+        case 2:
+          rowData.description = textContent;
+          break;
+      }
+    }
+  });
+  
+  console.log('Extracted row data:', rowData);
+  return Object.keys(rowData).length > 0 ? rowData : null;
+}
+
+function handleButtonClick(event) {
+  const target = event.target;
+  const buttonElement = target.closest('[role="button"]');
+  
+  if (buttonElement && isNotionButton(buttonElement)) {
+    event.preventDefault();
+    event.stopPropagation();
+    
+    const rowData = extractRowData(buttonElement);
+    console.log('Button clicked, row data:', rowData);
+    
+    chrome.runtime.sendMessage({
+      action: 'openSidePanel',
+      data: rowData
+    });
+  }
+}
+
+document.addEventListener('click', handleButtonClick, true);
+
+chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
+  if (request.action === 'getPageData') {
+    sendResponse({ url: window.location.href });
+  }
+  return true;
+});

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -37,5 +37,8 @@
   },
   "side_panel": {
     "default_path": "sidepanel.html"
+  },
+  "background": {
+    "service_worker": "background.js"
   }
 }

--- a/src/sidepanel.tsx
+++ b/src/sidepanel.tsx
@@ -1,12 +1,75 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { createRoot } from 'react-dom/client';
 import './styles.css';
 
+interface RowData {
+  name?: string;
+  type?: string;
+  description?: string;
+}
+
 const SidePanel: React.FC = () => {
+  const [rowData, setRowData] = useState<RowData | null>(null);
+
+  useEffect(() => {
+    const loadRowData = async () => {
+      try {
+        const result = await chrome.storage.local.get(['currentRowData']);
+        if (result.currentRowData) {
+          setRowData(result.currentRowData);
+        }
+      } catch (error) {
+        console.error('Failed to load row data:', error);
+      }
+    };
+
+    loadRowData();
+
+    const handleStorageChange = (changes: any) => {
+      if (changes.currentRowData) {
+        setRowData(changes.currentRowData.newValue);
+      }
+    };
+
+    chrome.storage.local.onChanged.addListener(handleStorageChange);
+
+    return () => {
+      chrome.storage.local.onChanged.removeListener(handleStorageChange);
+    };
+  }, []);
+
   return (
     <div className="p-6 h-full bg-gray-50">
       <h1 className="text-3xl font-bold text-gray-800 mb-4">ShellAgent</h1>
-      <p className="text-gray-600">侧边栏面板已打开</p>
+      
+      {rowData ? (
+        <div className="bg-white rounded-lg shadow-md p-4 mb-4">
+          <h2 className="text-xl font-semibold text-gray-800 mb-3">当前行数据</h2>
+          
+          {rowData.name && (
+            <div className="mb-2">
+              <span className="font-medium text-gray-700">名称: </span>
+              <span className="text-gray-600">{rowData.name}</span>
+            </div>
+          )}
+          
+          {rowData.type && (
+            <div className="mb-2">
+              <span className="font-medium text-gray-700">类型: </span>
+              <span className="text-gray-600">{rowData.type}</span>
+            </div>
+          )}
+          
+          {rowData.description && (
+            <div className="mb-2">
+              <span className="font-medium text-gray-700">描述: </span>
+              <span className="text-gray-600">{rowData.description}</span>
+            </div>
+          )}
+        </div>
+      ) : (
+        <p className="text-gray-600">点击页面上的 button 以显示行数据</p>
+      )}
     </div>
   );
 };

--- a/tasks.md
+++ b/tasks.md
@@ -1,21 +1,8 @@
-如果要给 notion 开发 extension，是用 chrome extension ？还是 notion extension
-1. chrome extension 作为 UI 容器
-2. 如果需要和 notion 交互，走 notion API
-3. 更新走 chrome store
+notion 添加 button
+button click 发送一个 webhook
+webhook 再通知 chrome extension
+有点绕 
 
+还有一种方式是识别当前 notion，增加监听
+这样就不用集成 webhook 了
 
----
-
-帮我生成一个 chrome extension demo 项目
-
----
-
-教我怎么发布到 chrome store
-
----
-
-chrome extension 是否有办法打开一个固定的侧边栏？
-
----
-
-改成一个 webpack 项目

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -20,7 +20,8 @@ module.exports = {
   entry: {
     popup: './src/popup.tsx',
     content: './src/content.js',
-    sidepanel: './src/sidepanel.tsx'
+    sidepanel: './src/sidepanel.tsx',
+    background: './src/background.js'
   },
   output: {
     path: path.resolve(__dirname, 'dist'),


### PR DESCRIPTION
- Create background service worker for side panel management
- Implement button click detection in content script for Notion tables
- Extract row data (name, type, description) from table cells
- Add data passing between content script and side panel via chrome.storage
- Update side panel to display current row data dynamically
- Configure webpack to include background script in build

🤖 Generated with [Claude Code](https://claude.ai/code)